### PR TITLE
fix: Remove elasticsearch legacy reference

### DIFF
--- a/packages/@aws-cdk/aws-elasticsearch/README.md
+++ b/packages/@aws-cdk/aws-elasticsearch/README.md
@@ -1,4 +1,4 @@
-# Amazon OpenSearch Service (legacy Elasticsearch) Construct Library
+# Amazon OpenSearch Service Construct Library
 <!--BEGIN STABILITY BANNER-->
 
 ---


### PR DESCRIPTION
Elastic has followed up with a request that we remove "legacy Elasticsearch" references from our docs for legal reasons.

They supplied these two links to remove the string from: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_elasticsearch-readme.html https://docs.aws.amazon.com/cdk/api/v1/docs/aws-elasticsearch-readme.html

This PR is for v1 (the second link). Does updating v1 automatically update v2?

Closes https://t.corp.amazon.com/V825034754.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
